### PR TITLE
check component registry before defining

### DIFF
--- a/src/ilw-header.js
+++ b/src/ilw-header.js
@@ -206,4 +206,4 @@ class Header extends LitElement {
     }
 }
 
-customElements.define('ilw-header', Header);
+customElements.get('ilw-header') || customElements.define('ilw-header', Header);


### PR DESCRIPTION
## Summary

Prevents fatal errors on page load if ilw-header has already been defined (e.g., due to bundle misconfiguration).